### PR TITLE
Add Python 2.6 support back in (?)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@
 language: python
 
 python:
-  - "3.3"
+  - "2.6"
   - "2.7"
+  - "3.3"
   - "pypy"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/etcaetera/adapter/base.py
+++ b/etcaetera/adapter/base.py
@@ -25,7 +25,7 @@ class Adapter(object):
         return self.__class__.__name__
 
     def __repr__(self):
-        return '<{} {}>'.format(self.__str__(), id(self))
+        return '<{0} {1}>'.format(self.__str__(), id(self))
 
     def __getitem__(self, key):
         if is_nested_key(key):

--- a/etcaetera/adapter/defaults.py
+++ b/etcaetera/adapter/defaults.py
@@ -9,4 +9,4 @@ class Defaults(Adapter):
         self.load()
 
     def load(self, formatter=None):
-        self.data = {self.format(k, formatter): v for k,v in self.data.items()}
+        self.data = dict((self.format(k, formatter), v) for k,v in self.data.items())

--- a/etcaetera/adapter/env.py
+++ b/etcaetera/adapter/env.py
@@ -25,7 +25,7 @@ class Env(Adapter):
     def __init__(self, *keys, **mapping):
         super(Env, self).__init__()
         self.keys = [format_key(k) for k in keys]
-        self.mapping = {format_key(k): format_key(v) for k, v in mapping.items()}
+        self.mapping = dict((format_key(k), format_key(v)) for k, v in mapping.items())
 
     def load(self, formatter=None):
         env_keys = self.keys + list(self.mapping.keys())

--- a/etcaetera/adapter/file.py
+++ b/etcaetera/adapter/file.py
@@ -35,17 +35,17 @@ class File(Adapter):
 
         if file_extension.lower() in JSON_EXTENSIONS:
             import json
-            self.data = {self.format(k, formatter): v for k, v in json.load(fd).items()}
+            self.data = dict((self.format(k, formatter), v) for k, v in json.load(fd).items())
         elif file_extension.lower() in YAML_EXTENSIONS:
             from yaml import load as yload, dump as ydump
             try:
                 from yaml import CLoader as Loader
             except ImportError:
                 from yaml import Loader
-            self.data = {self.format(k, formatter):v for k,v in yload(fd, Loader=Loader).items()}
+            self.data = dict((self.format(k, formatter), v) for k, v in yload(fd, Loader=Loader).items())
         elif file_extension.lower() in PYTHON_EXTENSIONS:
             mod = imp.load_source('mod', self.filepath)
-            self.data = {self.format(k, formatter): v for k, v in vars(mod).items() if k.isupper()}
+            self.data = dict((self.format(k, formatter), v) for k, v in vars(mod).items() if k.isupper())
         else:
             raise ValueError("Unhandled file extension {0}".format(file_extension))
 

--- a/etcaetera/adapter/file.py
+++ b/etcaetera/adapter/file.py
@@ -20,7 +20,7 @@ class File(Adapter):
 
     def strictness_check(self):
         if not os.path.exists(self.filepath):
-            raise IOError("Path {} does not exist".format(self.filepath))
+            raise IOError("Path {0} does not exist".format(self.filepath))
 
     def load(self, formatter=None):
         try:

--- a/etcaetera/adapter/module.py
+++ b/etcaetera/adapter/module.py
@@ -12,5 +12,5 @@ class Module(Adapter):
         self.module = mod
 
     def load(self, formatter=None):
-        self.data = {self.format(k, formatter): v for k,v in vars(self.module).items()
-                     if k.isupper()}
+        self.data = dict((self.format(k, formatter), v) for k,v in vars(self.module).items()
+                     if k.isupper())

--- a/etcaetera/adapter/overrides.py
+++ b/etcaetera/adapter/overrides.py
@@ -9,4 +9,4 @@ class Overrides(Adapter):
         self.load()
 
     def load(self, formatter=None):
-        self.data = {self.format(k, formatter): v for k, v in self.data.items()}
+        self.data = dict((self.format(k, formatter), v) for k, v in self.data.items())

--- a/etcaetera/adapter/set.py
+++ b/etcaetera/adapter/set.py
@@ -11,10 +11,10 @@ class AdapterSet(deque):
         self._load_adapters(adapters)
 
     def __repr__(self):
-        return 'AdapterSet{}'.format(self.__str__())
+        return 'AdapterSet{0}'.format(self.__str__())
 
     def __str__(self):
-        return '({})'.format(', '.join([a.__str__() for a in self]))
+        return '({0})'.format(', '.join([a.__str__() for a in self]))
 
     def __setitem__(self, key, value):
         if isinstance(value, Defaults) and key != 0:

--- a/etcaetera/config.py
+++ b/etcaetera/config.py
@@ -44,7 +44,7 @@ class Config(dict):
         if not isinstance(subconfig, Config):
             raise TypeError(
                 "Subconfig has to be of Config type. "
-                "Got {} instead".format(type(subconfig))
+                "Got {0} instead".format(type(subconfig))
             )
 
         self._subconfigs[name] = subconfig

--- a/etcaetera/config.py
+++ b/etcaetera/config.py
@@ -84,7 +84,7 @@ class Config(dict):
         # Adapters loading
         for adapter in self.adapters:
             adapter.load(formatter=self.formatter)
-            formatted_adapter_data = {self.formatter(k): v for k, v in adapter.data.items()}
+            formatted_adapter_data = dict((self.formatter(k), v) for k, v in adapter.data.items())
             self.update(formatted_adapter_data)
 
         # Subconfigs loading

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         "Programming Language :: Python :: 2",
+        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33
+envlist = py26, py27, py33
 
 [testenv]
 setenv =


### PR DESCRIPTION
Hi, thanks for etcaetera!

I'm hoping to use it in a Python 2.6->3.4 project, and needed to fix the below handful of 2.7-isms for it to install and import under 2.6.

Given your git history it looks like 2.6 support was (partially - it's still in `CONTRIBUTING.rst`) dropped when you added 3.x support. However, as the diff shows, the only nontrivial change needed for 2.6 to work is rolling back the dict comprehensions. I'm hoping you find it a worthwhile tradeoff (I researched for my own projects & found 2.6 still has a nontrivial install base.)

I'm able to install, import `config.Config`, and run `runtests.py`, all successfully on Python 2.6, 2.7 and 3.4; Travis will show in a bit whether it still works on 3.3.
