### PR TITLE
Relative imports

### DIFF
--- a/etcaetera/adapter/base.py
+++ b/etcaetera/adapter/base.py
@@ -5,8 +5,8 @@ try:
 except ImportError:
     pass
 
-from etcaetera.utils import is_nested_key
-from etcaetera.formatters import uppercased
+from ..utils import is_nested_key
+from ..formatters import uppercased
 
 
 Tree = lambda: defaultdict(Tree)

--- a/etcaetera/adapter/defaults.py
+++ b/etcaetera/adapter/defaults.py
@@ -1,5 +1,5 @@
-from etcaetera.adapter.base import Adapter
-from etcaetera.utils import format_key
+from .base import Adapter
+from ..utils import format_key
 
 
 class Defaults(Adapter):

--- a/etcaetera/adapter/env.py
+++ b/etcaetera/adapter/env.py
@@ -1,7 +1,7 @@
 import os
 
-from etcaetera.adapter.base import Adapter
-from etcaetera.utils import format_key
+from .base import Adapter
+from ..utils import format_key
 
 
 class Env(Adapter):

--- a/etcaetera/adapter/file.py
+++ b/etcaetera/adapter/file.py
@@ -1,9 +1,9 @@
 import os
 import imp
 
-from etcaetera.adapter.base import Adapter
-from etcaetera.utils import format_key
-from etcaetera.constants import (
+from .base import Adapter
+from ..utils import format_key
+from ..constants import (
     JSON_EXTENSIONS,
     YAML_EXTENSIONS,
     PYTHON_EXTENSIONS

--- a/etcaetera/adapter/module.py
+++ b/etcaetera/adapter/module.py
@@ -1,6 +1,6 @@
 import types
 
-from etcaetera.adapter.base import Adapter
+from .base import Adapter
 
 
 class Module(Adapter):

--- a/etcaetera/adapter/overrides.py
+++ b/etcaetera/adapter/overrides.py
@@ -1,5 +1,5 @@
-from etcaetera.adapter.base import Adapter
-from etcaetera.utils import format_key
+from .base import Adapter
+from ..utils import format_key
 
 
 class Overrides(Adapter):

--- a/etcaetera/adapter/set.py
+++ b/etcaetera/adapter/set.py
@@ -1,8 +1,8 @@
 from collections import deque
 
-from etcaetera.adapter.base import Adapter
-from etcaetera.adapter.defaults import Defaults
-from etcaetera.adapter.overrides import Overrides
+from .base import Adapter
+from .defaults import Defaults
+from .overrides import Overrides
 
 
 class AdapterSet(deque):

--- a/etcaetera/config.py
+++ b/etcaetera/config.py
@@ -1,7 +1,7 @@
 from collections import deque, namedtuple
 
-from etcaetera.formatters import uppercased
-from etcaetera.adapter import (
+from .formatters import uppercased
+from .adapter import (
     Adapter,
     AdapterSet,
     Defaults,

--- a/etcaetera/utils.py
+++ b/etcaetera/utils.py
@@ -1,5 +1,5 @@
-from etcaetera.formatters import environ
-from etcaetera.exceptions import MalformationError
+from .formatters import environ
+from .exceptions import MalformationError
 
 
 def format_key(key):


### PR DESCRIPTION
Hi again,

I'm currently vendoring etcaetera inside my own project (for a handful of reasons) and to make it work well in that situation I needed to make the various self-imports relative instead of absolute (using the new-as-of-Python-2.6 dot syntax).

The nice thing about this change is it's transparent for regular `pip install` users, and saves a handful of characters otherwise ;)
