### PR TITLE
AdapterSet.insert() doesn't work in nontrivial situations

### DIFF
--- a/etcaetera/adapter/set.py
+++ b/etcaetera/adapter/set.py
@@ -138,9 +138,13 @@ class AdapterSet(deque):
         elif index >= len(self):
             self.append(adapter)
         else:
-            self.rotate(index)
+            # Use deque.rotate to roll forward (right) enough that we can
+            # append the new one at desired spot, then use rotate with a
+            # negative index to roll back to our starting point.
+            focus = len(self) - index
+            self.rotate(focus)
             self.append(adapter)
-            self.rotate(-index)
+            self.rotate(-focus)
 
     def _load_adapters(self, adapters):
         for index, adapter in enumerate(adapters):

--- a/tests/adapter/test_set.py
+++ b/tests/adapter/test_set.py
@@ -224,3 +224,64 @@ class TestAdapterSet:
         assert len(s) == 3
         assert isinstance(s[1], Env)
 
+    def test_insert_at_end_with_overrides(self):
+        s = AdapterSet(
+            Defaults(),
+            File('meh', strict=False),
+            File('meh2', strict=False),
+            Overrides()
+        )
+        s.insert(3, Env())
+        assert len(s) == 5
+        assert isinstance(s[3], Env)
+
+    def test_insert_in_middle_with_overrides(self):
+        s = AdapterSet(
+            Defaults(),
+            File('meh', strict=False),
+            File('meh2', strict=False),
+            Overrides()
+        )
+        s.insert(2, Env())
+        assert len(s) == 5
+        assert isinstance(s[2], Env)
+
+    def test_insert_in_middle_without_overrides(self):
+        s = AdapterSet(
+            Defaults(),
+            File('meh', strict=False),
+            File('meh2', strict=False),
+        )
+        s.insert(2, Env())
+        assert len(s) == 4
+        assert isinstance(s[2], Env)
+
+    def test_insert_at_end_without_overrides(self):
+        s = AdapterSet(
+            Defaults(),
+            File('meh', strict=False),
+            File('meh2', strict=False),
+        )
+        s.insert(3, Env())
+        assert len(s) == 4
+        assert isinstance(s[3], Env)
+
+    def test_insert_at_end_without_overrides_or_defaults(self):
+        s = AdapterSet(
+            File('meh', strict=False),
+            File('meh2', strict=False),
+            File('meh3', strict=False),
+        )
+        s.insert(3, Env())
+        assert len(s) == 4
+        assert isinstance(s[3], Env)
+
+    def test_insert_in_middle_without_overrides_or_defaults(self):
+        s = AdapterSet(
+            File('meh', strict=False),
+            File('meh2', strict=False),
+            File('meh3', strict=False),
+        )
+        s.insert(2, Env())
+        assert len(s) == 4
+        assert isinstance(s[2], Env)


### PR DESCRIPTION
Ran into a silly bug:
- Have `Config` with a bunch (~10) of `File` adapters + a `Defaults`
- Register an `Overrides`
- Try registering an `Env` adapter after that
- `Config.register` sees the `Overrides` and opts to use `AdapterSet.insert` instead of `.append` (which is used for all other register calls prior to adding the `Overrides`)
- `insert` doesn't work correctly when you have >1 adapter in-between your `Defaults` and your `Overrides` - it's using incorrect indexes when calling `deque.rotate`.

Started this PR with a failing test proving what I found.

Poking at the fix now, guessing just needs a couple numbers peeled off of the `index` value based on the existence of `Defaults` and/or `Overrides`.
